### PR TITLE
Download links for versions 2.2.4 to 2.2.6 added to docs

### DIFF
--- a/user_guide_src/source/installation/downloads.rst
+++ b/user_guide_src/source/installation/downloads.rst
@@ -18,6 +18,9 @@ Downloading CodeIgniter
 -  `CodeIgniter v3.0.2 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/3.0.2>`_
 -  `CodeIgniter v3.0.1 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/3.0.1>`_
 -  `CodeIgniter v3.0.0 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/3.0.0>`_
+-  `CodeIgniter v2.2.6 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.6>`_
+-  `CodeIgniter v2.2.5 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.5>`_
+-  `CodeIgniter v2.2.4 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.4>`_
 -  `CodeIgniter v2.2.3 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.3>`_
 -  `CodeIgniter v2.2.2 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.2>`_
 -  `CodeIgniter v2.2.1 <https://codeload.github.com/bcit-ci/CodeIgniter/zip/2.2.1>`_


### PR DESCRIPTION
CodeIgniter 2.2.6 is the latest supported version of CodeIgniter2 and the documentation (Installation Instructions » Downloading CodeIgniter) only shows CI2 links up to 2.2.3. This links can be useful when trying to upgrade from CI2 to CI3, at least to update to the latest CI2 version before shifting to CI3.